### PR TITLE
Added instructions to sync fork with upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ It will then calculate the man hours saved and its equivalent cost savings, as w
   git checkout -b yourname/feature-description
   ```
 ### 2. Sync Your Branch with main Regularly:
-- Fetch the latest changes and rebase your branch before creating or updating a PR:
+- Use the `Sync fork` button provided on Github before making any changes.
+
+<img width="1440" alt="Screenshot 2024-12-09 at 10 03 28 AM" src="https://github.com/user-attachments/assets/5998c1eb-b2cd-43fc-9c61-0c51be9884e9">
+
+
+- Alternatively, from the command line fetch latest changes and rebase your branch before creating or updating a PR:
   ```
   git fetch origin
   git rebase origin/main


### PR DESCRIPTION
We are observing a few PRs from forks that are not `synced` with the `main` branch from the upstream repository https://github.com/Mindshift-Analytics/roicalculator/ So, adding this step to the `README` so that it aids new contributors send proper Pull Requests for review.